### PR TITLE
feat: add combined GitHub + GitLab contribution heatmap

### DIFF
--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -1,0 +1,47 @@
+name: Update contributions data
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily at 06:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - scripts/build-contributions.mjs
+      - .github/workflows/contributions.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: contributions
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch GitHub + GitLab contributions
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_USER: NickBourque
+          GL_USER: nickabourque
+        run: node scripts/build-contributions.mjs
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- _data/contributions.json; then
+            echo "No contribution changes."
+          else
+            git add _data/contributions.json
+            git commit -m "chore: refresh contributions data"
+            git push
+          fi

--- a/_data/contributions.json
+++ b/_data/contributions.json
@@ -1,0 +1,435 @@
+{
+  "generated": "2026-06-29",
+  "totals": {
+    "github": 38,
+    "gitlab": 2932,
+    "combined": 2970
+  },
+  "max": 141,
+  "weeks": [
+    {
+      "weekStart": "2025-06-29",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 37,
+      "total": 37,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-07-06",
+      "monthLabel": "Jul",
+      "gh": 0,
+      "gl": 63,
+      "total": 63,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-07-13",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 0,
+      "total": 0,
+      "level": 0
+    },
+    {
+      "weekStart": "2025-07-20",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 63,
+      "total": 63,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-07-27",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 38,
+      "total": 38,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-08-03",
+      "monthLabel": "Aug",
+      "gh": 0,
+      "gl": 25,
+      "total": 25,
+      "level": 1
+    },
+    {
+      "weekStart": "2025-08-10",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 0,
+      "total": 0,
+      "level": 0
+    },
+    {
+      "weekStart": "2025-08-17",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 76,
+      "total": 76,
+      "level": 3
+    },
+    {
+      "weekStart": "2025-08-24",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 79,
+      "total": 79,
+      "level": 3
+    },
+    {
+      "weekStart": "2025-08-31",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 1,
+      "total": 1,
+      "level": 1
+    },
+    {
+      "weekStart": "2025-09-07",
+      "monthLabel": "Sep",
+      "gh": 0,
+      "gl": 64,
+      "total": 64,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-09-14",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 82,
+      "total": 82,
+      "level": 3
+    },
+    {
+      "weekStart": "2025-09-21",
+      "monthLabel": "",
+      "gh": 1,
+      "gl": 54,
+      "total": 55,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-09-28",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 10,
+      "total": 10,
+      "level": 1
+    },
+    {
+      "weekStart": "2025-10-05",
+      "monthLabel": "Oct",
+      "gh": 0,
+      "gl": 47,
+      "total": 47,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-10-12",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 61,
+      "total": 61,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-10-19",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 88,
+      "total": 88,
+      "level": 3
+    },
+    {
+      "weekStart": "2025-10-26",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 44,
+      "total": 44,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-11-02",
+      "monthLabel": "Nov",
+      "gh": 0,
+      "gl": 71,
+      "total": 71,
+      "level": 3
+    },
+    {
+      "weekStart": "2025-11-09",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 24,
+      "total": 24,
+      "level": 1
+    },
+    {
+      "weekStart": "2025-11-16",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 107,
+      "total": 107,
+      "level": 4
+    },
+    {
+      "weekStart": "2025-11-23",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 51,
+      "total": 51,
+      "level": 2
+    },
+    {
+      "weekStart": "2025-11-30",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 29,
+      "total": 29,
+      "level": 1
+    },
+    {
+      "weekStart": "2025-12-07",
+      "monthLabel": "Dec",
+      "gh": 0,
+      "gl": 75,
+      "total": 75,
+      "level": 3
+    },
+    {
+      "weekStart": "2025-12-14",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 31,
+      "total": 31,
+      "level": 1
+    },
+    {
+      "weekStart": "2025-12-21",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 0,
+      "total": 0,
+      "level": 0
+    },
+    {
+      "weekStart": "2025-12-28",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 0,
+      "total": 0,
+      "level": 0
+    },
+    {
+      "weekStart": "2026-01-04",
+      "monthLabel": "Jan",
+      "gh": 0,
+      "gl": 42,
+      "total": 42,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-01-11",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 35,
+      "total": 35,
+      "level": 1
+    },
+    {
+      "weekStart": "2026-01-18",
+      "monthLabel": "",
+      "gh": 1,
+      "gl": 65,
+      "total": 66,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-01-25",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 52,
+      "total": 52,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-02-01",
+      "monthLabel": "Feb",
+      "gh": 0,
+      "gl": 67,
+      "total": 67,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-02-08",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 76,
+      "total": 76,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-02-15",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 58,
+      "total": 58,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-02-22",
+      "monthLabel": "",
+      "gh": 5,
+      "gl": 29,
+      "total": 34,
+      "level": 1
+    },
+    {
+      "weekStart": "2026-03-01",
+      "monthLabel": "Mar",
+      "gh": 1,
+      "gl": 49,
+      "total": 50,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-03-08",
+      "monthLabel": "",
+      "gh": 7,
+      "gl": 30,
+      "total": 37,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-03-15",
+      "monthLabel": "",
+      "gh": 2,
+      "gl": 31,
+      "total": 33,
+      "level": 1
+    },
+    {
+      "weekStart": "2026-03-22",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 57,
+      "total": 57,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-03-29",
+      "monthLabel": "",
+      "gh": 10,
+      "gl": 32,
+      "total": 42,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-04-05",
+      "monthLabel": "Apr",
+      "gh": 0,
+      "gl": 73,
+      "total": 73,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-04-12",
+      "monthLabel": "",
+      "gh": 1,
+      "gl": 84,
+      "total": 85,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-04-19",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 103,
+      "total": 103,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-04-26",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 0,
+      "total": 0,
+      "level": 0
+    },
+    {
+      "weekStart": "2026-05-03",
+      "monthLabel": "May",
+      "gh": 0,
+      "gl": 69,
+      "total": 69,
+      "level": 2
+    },
+    {
+      "weekStart": "2026-05-10",
+      "monthLabel": "",
+      "gh": 1,
+      "gl": 140,
+      "total": 141,
+      "level": 4
+    },
+    {
+      "weekStart": "2026-05-17",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 91,
+      "total": 91,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-05-24",
+      "monthLabel": "",
+      "gh": 1,
+      "gl": 102,
+      "total": 103,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-05-31",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 111,
+      "total": 111,
+      "level": 4
+    },
+    {
+      "weekStart": "2026-06-07",
+      "monthLabel": "Jun",
+      "gh": 0,
+      "gl": 130,
+      "total": 130,
+      "level": 4
+    },
+    {
+      "weekStart": "2026-06-14",
+      "monthLabel": "",
+      "gh": 8,
+      "gl": 77,
+      "total": 85,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-06-21",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 89,
+      "total": 89,
+      "level": 3
+    },
+    {
+      "weekStart": "2026-06-28",
+      "monthLabel": "",
+      "gh": 0,
+      "gl": 20,
+      "total": 20,
+      "level": 1
+    }
+  ]
+}

--- a/_includes/contributions.html
+++ b/_includes/contributions.html
@@ -1,0 +1,41 @@
+{% assign c = site.data.contributions %}
+{% if c %}
+<div class="contrib-card">
+  <div class="contrib-stats">
+    <span class="contrib-stat contrib-stat-gitlab">
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m22 13.29-3.33-10a.42.42 0 0 0-.14-.18.38.38 0 0 0-.22-.11.39.39 0 0 0-.23.07.42.42 0 0 0-.14.18l-2.26 6.67H8.32L6.1 3.26a.42.42 0 0 0-.1-.18.38.38 0 0 0-.26-.08.39.39 0 0 0-.23.07.42.42 0 0 0-.14.18L2 13.29a.74.74 0 0 0 .27.83L12 21l9.69-6.88a.71.71 0 0 0 .31-.83Z"/></svg>
+      <strong>{{ c.totals.gitlab }}</strong> GitLab
+    </span>
+    <span class="contrib-stat contrib-stat-github">
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
+      <strong>{{ c.totals.github }}</strong> GitHub
+    </span>
+    <span class="contrib-stat contrib-stat-total">
+      <strong>{{ c.totals.combined }}</strong> contributions in the last year
+    </span>
+  </div>
+
+  <div class="contrib-scroll">
+    <div class="contrib-chart">
+      <div class="contrib-months">
+        {% for week in c.weeks %}
+        <span class="contrib-month">{{ week.monthLabel }}</span>
+        {% endfor %}
+      </div>
+      <div class="contrib-grid" role="img" aria-label="Combined GitLab and GitHub contribution activity per week over the past year">
+        {% for week in c.weeks %}<div class="contrib-day contrib-l{{ week.level }}{% if forloop.last %} contrib-current{% endif %}" data-week="{{ week.weekStart }}" data-gh="{{ week.gh }}" data-gl="{{ week.gl }}" data-total="{{ week.total }}" title="Week of {{ week.weekStart }} — {{ week.total }} contribution{% if week.total != 1 %}s{% endif %} (GitLab {{ week.gl }}, GitHub {{ week.gh }})"></div>{% endfor %}
+      </div>
+    </div>
+  </div>
+
+  <div class="contrib-legend">
+    <span>Less</span>
+    <div class="contrib-day contrib-l0"></div>
+    <div class="contrib-day contrib-l1"></div>
+    <div class="contrib-day contrib-l2"></div>
+    <div class="contrib-day contrib-l3"></div>
+    <div class="contrib-day contrib-l4"></div>
+    <span>More</span>
+  </div>
+</div>
+{% endif %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1612,3 +1612,185 @@ body.light-mode .theme-toggle-btn .moon-icon { display: none; }
     gap: 1rem;
   }
 }
+
+/* ============================================================
+   Combined GitHub + GitLab contributions heatmap
+   ============================================================ */
+:root {
+  --contrib-cell: 16px;
+  --contrib-week-h: 40px;
+  --contrib-gap: 4px;
+  --contrib-l0: var(--bg-tertiary);
+  --contrib-l1: rgba(16, 185, 129, 0.28);
+  --contrib-l2: rgba(16, 185, 129, 0.52);
+  --contrib-l3: rgba(16, 185, 129, 0.78);
+  --contrib-l4: linear-gradient(135deg, #10b981 0%, #8b5cf6 100%);
+}
+
+body.light-mode {
+  --contrib-l0: #e7edf4;
+  --contrib-l1: rgba(5, 150, 105, 0.22);
+  --contrib-l2: rgba(5, 150, 105, 0.45);
+  --contrib-l3: rgba(5, 150, 105, 0.72);
+  --contrib-l4: linear-gradient(135deg, #059669 0%, #7c3aed 100%);
+}
+
+.contrib-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  padding: 2rem;
+  border-radius: var(--border-radius-md);
+}
+
+.contrib-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem 1.75rem;
+  margin-bottom: 1.75rem;
+}
+.contrib-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+.contrib-stat strong {
+  color: var(--text-primary);
+  font-family: var(--font-heading);
+  font-weight: 700;
+}
+.contrib-stat-github svg { color: var(--accent-secondary); }
+.contrib-stat-gitlab svg { color: var(--accent-primary); }
+.contrib-stat-total { margin-left: auto; color: var(--text-muted); }
+
+.contrib-scroll {
+  overflow-x: auto;
+  /* Vertical room so the current-week pulse glow isn't clipped by the scroll box. */
+  padding: 10px 8px;
+}
+
+.contrib-chart {
+  display: inline-block;
+  min-width: max-content;
+}
+
+.contrib-months {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: calc(var(--contrib-cell) + var(--contrib-gap));
+  margin-bottom: 0.4rem;
+}
+.contrib-month {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: visible;
+}
+
+.contrib-grid {
+  display: grid;
+  grid-template-rows: var(--contrib-week-h);
+  grid-auto-flow: column;
+  grid-auto-columns: var(--contrib-cell);
+  gap: var(--contrib-gap);
+}
+
+.contrib-day {
+  width: var(--contrib-cell);
+  height: var(--contrib-week-h);
+  border-radius: 4px;
+  background: var(--contrib-l0);
+  transition: transform var(--transition-fast);
+}
+
+/* Square swatches in the legend even though grid blocks are tall. */
+.contrib-legend .contrib-day {
+  height: var(--contrib-cell);
+}
+.contrib-l0 { background: var(--contrib-l0); }
+.contrib-l1 { background: var(--contrib-l1); }
+.contrib-l2 { background: var(--contrib-l2); }
+.contrib-l3 { background: var(--contrib-l3); }
+.contrib-l4 { background: var(--contrib-l4); }
+.contrib-future { background: transparent; }
+
+.contrib-grid .contrib-day:hover {
+  transform: scale(1.15);
+  outline: 1.5px solid var(--text-secondary);
+  outline-offset: 1px;
+  cursor: pointer;
+}
+
+/* The week that contains today pulses to feel "live". */
+.contrib-day.contrib-current {
+  position: relative;
+  z-index: 1;
+  animation: contribPulse 2s ease-in-out infinite;
+}
+@keyframes contribPulse {
+  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.6); }
+  70% { box-shadow: 0 0 0 8px rgba(16, 185, 129, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .contrib-day.contrib-current { animation: none; box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.5); }
+}
+
+.contrib-legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.3rem;
+  margin-top: 1.25rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.contrib-legend span { margin: 0 0.25rem; }
+
+.contrib-tooltip {
+  position: fixed;
+  z-index: 1200;
+  pointer-events: none;
+  padding: 0.5rem 0.7rem;
+  border-radius: var(--border-radius-sm);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px var(--shadow-color);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+.contrib-tooltip.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.contrib-tooltip .contrib-tip-date {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  margin-bottom: 0.15rem;
+}
+.contrib-tooltip .contrib-tip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-secondary);
+}
+.contrib-tooltip .contrib-tip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.contrib-tooltip .contrib-tip-dot.gh { background: var(--accent-secondary); }
+.contrib-tooltip .contrib-tip-dot.gl { background: var(--accent-primary); }
+
+@media (max-width: 768px) {
+  .contrib-stat-total { margin-left: 0; flex-basis: 100%; }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -175,4 +175,46 @@ document.addEventListener('DOMContentLoaded', () => {
       revealObserver.observe(el);
     });
   }
+
+  // 9. Contribution heatmap tooltip (delegated; native title is the no-JS fallback)
+  const contribGrid = document.querySelector('.contrib-grid');
+  if (contribGrid) {
+    let tooltip = null;
+
+    const showTooltip = (cell) => {
+      if (!cell.dataset.week) return;
+      cell.removeAttribute('title'); // suppress the native tooltip while ours is shown
+      if (!tooltip) {
+        tooltip = document.createElement('div');
+        tooltip.className = 'contrib-tooltip';
+        document.body.appendChild(tooltip);
+      }
+      const total = cell.dataset.total;
+      tooltip.innerHTML =
+        `<div class="contrib-tip-date">Week of ${cell.dataset.week} &middot; ${total} contribution${total === '1' ? '' : 's'}</div>` +
+        `<div class="contrib-tip-row"><span class="contrib-tip-dot gl"></span>GitLab ${cell.dataset.gl}</div>` +
+        `<div class="contrib-tip-row"><span class="contrib-tip-dot gh"></span>GitHub ${cell.dataset.gh}</div>`;
+      const rect = cell.getBoundingClientRect();
+      tooltip.style.left = rect.left + rect.width / 2 + 'px';
+      tooltip.style.top = rect.top + 'px';
+      tooltip.style.transform = 'translate(-50%, calc(-100% - 8px))';
+      // Force reflow so the fade-in transition plays from the hidden state.
+      tooltip.classList.remove('visible');
+      void tooltip.offsetWidth;
+      tooltip.classList.add('visible');
+    };
+
+    const hideTooltip = () => {
+      if (tooltip) tooltip.classList.remove('visible');
+    };
+
+    contribGrid.addEventListener('mouseover', (e) => {
+      const cell = e.target.closest('.contrib-day');
+      if (cell && contribGrid.contains(cell)) showTooltip(cell);
+    });
+    contribGrid.addEventListener('mouseout', (e) => {
+      const cell = e.target.closest('.contrib-day');
+      if (cell) hideTooltip();
+    });
+  }
 });

--- a/index.html
+++ b/index.html
@@ -101,6 +101,17 @@ url: /
   </div>
 </section>
 
+<!-- Contributions Section -->
+<section class="contributions-section">
+  <div class="container">
+    <div class="section-header">
+      <h2 class="section-title">Contribution Activity</h2>
+      <p class="section-subtitle">A combined view of my GitHub and GitLab activity over the past year</p>
+    </div>
+    {% include contributions.html %}
+  </div>
+</section>
+
 <!-- Featured Projects Section -->
 {% comment %} Portfolio temporarily disabled — see _config.yml exclude list.
 <section class="featured-projects-section">

--- a/scripts/build-contributions.mjs
+++ b/scripts/build-contributions.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Fetches GitHub + GitLab contribution calendars and merges them into a single
+// year-long heatmap dataset written to _data/contributions.json.
+//
+// GitHub: GitHub GraphQL when GITHUB_TOKEN is set (CI), otherwise the keyless,
+//         CORS-enabled jogruber API (local dev). GitLab: public calendar.json.
+//
+// Run: node scripts/build-contributions.mjs  (no key needed locally)
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const GH_USER = process.env.GH_USER || 'NickBourque';
+const GL_USER = process.env.GL_USER || 'nickabourque';
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '..', '_data', 'contributions.json');
+
+const WEEKS = 53;
+const SHORT_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Treat every date as a UTC calendar day keyed by YYYY-MM-DD.
+const isoDay = (d) => d.toISOString().slice(0, 10);
+const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
+
+async function fetchGithub(user) {
+  if (TOKEN) {
+    const query = `query($login:String!){ user(login:$login){ contributionsCollection { contributionCalendar { weeks { contributionDays { date contributionCount } } } } } }`;
+    const res = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'contributions-builder',
+      },
+      body: JSON.stringify({ query, variables: { login: user } }),
+    });
+    if (!res.ok) throw new Error(`GitHub GraphQL ${res.status}: ${await res.text()}`);
+    const json = await res.json();
+    if (json.errors) throw new Error(`GitHub GraphQL: ${JSON.stringify(json.errors)}`);
+    const map = {};
+    for (const week of json.data.user.contributionsCollection.contributionCalendar.weeks) {
+      for (const day of week.contributionDays) map[day.date] = day.contributionCount;
+    }
+    return map;
+  }
+  // Keyless fallback for local runs.
+  const res = await fetch(`https://github-contributions-api.jogruber.de/v4/${user}?y=last`, {
+    headers: { 'User-Agent': 'contributions-builder' },
+  });
+  if (!res.ok) throw new Error(`jogruber API ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  const map = {};
+  for (const c of json.contributions || []) map[c.date] = c.count;
+  return map;
+}
+
+async function fetchGitlab(user) {
+  const res = await fetch(`https://gitlab.com/users/${user}/calendar.json`, {
+    headers: { 'User-Agent': 'contributions-builder', Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`GitLab calendar ${res.status}: ${await res.text()}`);
+  return await res.json(); // already { "YYYY-MM-DD": count }
+}
+
+function bucket(total, max) {
+  if (total <= 0) return 0;
+  if (max <= 0) return 1;
+  return Math.min(4, Math.max(1, Math.ceil((total / max) * 4)));
+}
+
+function build(ghMap, glMap) {
+  const today = new Date(isoDay(new Date()) + 'T00:00:00Z');
+  const dow = today.getUTCDay(); // 0 = Sunday
+  const lastSaturday = addDays(today, 6 - dow);
+  const firstSunday = addDays(lastSaturday, -(WEEKS * 7 - 1));
+  const todayKey = isoDay(today);
+
+  let totalGh = 0;
+  let totalGl = 0;
+  let max = 0;
+  const weeks = [];
+  let prevMonth = -1;
+
+  for (let w = 0; w < WEEKS; w++) {
+    let weekGh = 0;
+    let weekGl = 0;
+    let monthLabel = '';
+    let weekStart = '';
+    for (let i = 0; i < 7; i++) {
+      const date = addDays(firstSunday, w * 7 + i);
+      const key = isoDay(date);
+      if (i === 0) {
+        weekStart = key;
+        const m = date.getUTCMonth();
+        if (m !== prevMonth) {
+          // Skip the leading partial month so its label doesn't collide with the next.
+          if (w > 0) monthLabel = SHORT_MONTHS[m];
+          prevMonth = m;
+        }
+      }
+      if (key > todayKey) continue; // future days contribute nothing
+      weekGh += ghMap[key] || 0;
+      weekGl += glMap[key] || 0;
+    }
+    const total = weekGh + weekGl;
+    totalGh += weekGh;
+    totalGl += weekGl;
+    if (total > max) max = total;
+    weeks.push({ weekStart, monthLabel, gh: weekGh, gl: weekGl, total });
+  }
+
+  // Levels need the final (weekly) max, so assign in a second pass.
+  for (const week of weeks) {
+    week.level = bucket(week.total, max);
+  }
+
+  return {
+    generated: todayKey,
+    totals: { github: totalGh, gitlab: totalGl, combined: totalGh + totalGl },
+    max,
+    weeks,
+  };
+}
+
+async function main() {
+  const [ghMap, glMap] = await Promise.all([
+    fetchGithub(GH_USER).catch((e) => {
+      console.error(`GitHub fetch failed: ${e.message}`);
+      return {};
+    }),
+    fetchGitlab(GL_USER).catch((e) => {
+      console.error(`GitLab fetch failed: ${e.message}`);
+      return {};
+    }),
+  ]);
+
+  const data = build(ghMap, glMap);
+  await mkdir(dirname(OUT), { recursive: true });
+  await writeFile(OUT, JSON.stringify(data, null, 2) + '\n');
+  console.log(
+    `Wrote ${OUT} — GitHub ${data.totals.github}, GitLab ${data.totals.gitlab}, combined ${data.totals.combined} (max/day ${data.max}).`
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Weekly-aggregated contribution activity over the past year, summed across both platforms with a per-week color scale. Data is fetched server-side by a daily GitHub Action (GitHub GraphQL via GITHUB_TOKEN, public GitLab calendar.json) and committed to _data/contributions.json, so the heatmap renders statically with no client-side API calls or CORS issues.

Includes a live-pulsing current week, hover tooltips with per-platform breakdown, and dark/light theme support.